### PR TITLE
update context dependency and fix test case bug

### DIFF
--- a/generator/add_transport.go
+++ b/generator/add_transport.go
@@ -1137,7 +1137,7 @@ func (g *generateGRPCTransport) Generate() (err error) {
 				n,
 				jen.Id(stp).Id("*grpcServer"),
 				[]jen.Code{
-					jen.Id("ctx").Qual("golang.org/x/net/context", "Context"),
+					jen.Id("ctx").Qual("context", "Context"),
 					jen.Id("req").Id("*").Qual(pbImport, n+"Request"),
 				},
 				[]jen.Code{

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -87,7 +87,7 @@ func (b *BaseGenerator) GenerateNameBySample(sample string, exclude []parser.Nam
 		if v.Name == name {
 			sn++
 			if sn > len(sample) {
-				sample = string(len(sample) - sn)
+				sample = strconv.Itoa(len(sample) - sn)
 			}
 			name = utils.ToLowerFirstCamelCase(sample)[:sn]
 		}


### PR DESCRIPTION
- before we changed, when we generate gRPC code, it imports "golang.org/x/net/context" ,it will now import the "context" package
- fix a test case bug,it uses the wrong string conversion method