### PR TITLE
fix: fix comment disappear when missing import

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -12,10 +12,10 @@ import (
 	"bytes"
 	"go/format"
 
-	"github.com/dave/jennifer/jen"
 	"github.com/GrantZheng/kit/fs"
 	"github.com/GrantZheng/kit/parser"
 	"github.com/GrantZheng/kit/utils"
+	"github.com/dave/jennifer/jen"
 	"github.com/sirupsen/logrus"
 )
 
@@ -117,7 +117,7 @@ func (b *BaseGenerator) EnsureThatWeUseQualifierIfNeeded(tp string, imp []parser
 func (b *BaseGenerator) AddImportsToFile(imp []parser.NamedTypeValue, src string) (string, error) {
 	// Create the AST by parsing src
 	fset := token.NewFileSet()
-	f, err := ps.ParseFile(fset, "", src, 0)
+	f, err := ps.ParseFile(fset, "", src, ps.ParseComments)
 	if err != nil {
 		return "", err
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -8,8 +8,8 @@ import (
 
 	"fmt"
 
-	"github.com/alioygur/godash"
 	"github.com/GrantZheng/kit/fs"
+	"github.com/alioygur/godash"
 	"github.com/spf13/viper"
 	"golang.org/x/tools/imports"
 )
@@ -50,7 +50,7 @@ func ToCamelCase(s string) string {
 // GoImportsSource is used to format and optimize imports the
 // given source.
 func GoImportsSource(path string, s string) (string, error) {
-	is, err := imports.Process(path, []byte(s), nil)
+	is, err := imports.Process(path, []byte(s), &imports.Options{Comments: true})
 	return string(is), err
 }
 


### PR DESCRIPTION
Need to add parse comment options, or all comments will disappear when the file is missing imports.